### PR TITLE
fix: #14

### DIFF
--- a/dialogy/types/entity/base_entity.py
+++ b/dialogy/types/entity/base_entity.py
@@ -101,6 +101,9 @@ class BaseEntity:
 
     __properties_map = const.BASE_ENTITY_PROPS
 
+    def __attrs_post_init__(self) -> None:
+        self.entity_type = self.type
+
     @classmethod
     def validate(cls, dict_: Dict[str, Any]) -> None:
         """

--- a/tests/types/entity/test_entities.py
+++ b/tests/types/entity/test_entities.py
@@ -318,3 +318,15 @@ def test_entity_grain_to_type() -> None:
     )
     assert entity.entity_type == "hour"
     assert entity.type == "hour"
+
+
+def test_both_entity_type_attributes_match() -> None:
+    body = "4 things"
+    value = {"value": 4}
+    entity = BaseEntity(
+        range={"from": 0, "to": len(body)},
+        body=body,
+        type="base",
+        values=[value],
+    )
+    assert entity.type == entity.entity_type


### PR DESCRIPTION
We saw time related entities TimeEntity and TimeIntervalEntity check the grain and type
and eventually get in sync. Other entities didn't share this property. We added an explicit copy
post entity initialization for BaseEntity. This will ensure all entities at-least start out with
the same `entity.entity_type` and `entity.type`