### PR TITLE
Fix/#17/time interval entity format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ docs_src/_build/
 # IDEs
 .vscode/
 .idea/
+
+.DS_Store

--- a/dialogy/parser/text/entity/duckling_parser.py
+++ b/dialogy/parser/text/entity/duckling_parser.py
@@ -226,9 +226,12 @@ class DucklingParser(Plugin):
         if EntityKeys.GRAIN in entity[EntityKeys.VALUE]:
             entity[EntityKeys.GRAIN] = entity[EntityKeys.VALUE][EntityKeys.GRAIN]
         elif entity[EntityKeys.VALUE][EntityKeys.TYPE] == EntityKeys.INTERVAL:
-            entity[EntityKeys.GRAIN] = entity[EntityKeys.VALUE][EntityKeys.TO][
-                EntityKeys.GRAIN
-            ]
+            date_range = entity[EntityKeys.VALUE].get(EntityKeys.FROM) or entity[
+                EntityKeys.VALUE
+            ].get(EntityKeys.TO)
+            if not date_range:
+                raise TypeError(f"{entity} does not match TimeIntervalEntity format")
+            entity[EntityKeys.GRAIN] = date_range[EntityKeys.GRAIN]
 
         del entity[EntityKeys.START]
         del entity[EntityKeys.END]

--- a/dialogy/types/entity/time_interval_entity.py
+++ b/dialogy/types/entity/time_interval_entity.py
@@ -44,10 +44,8 @@ class TimeIntervalEntity(TimeEntity):
             self.value = self.values[0]
         else:
             if value:
-                if (
-                    isinstance(value, dict)
-                    and const.TO in value
-                    and const.FROM in value
+                if isinstance(value, dict) and (
+                    const.FROM in value or const.TO in value
                 ):
                     self.values = [value]
                     self.value = value

--- a/tests/parser/text/entity/config.py
+++ b/tests/parser/text/entity/config.py
@@ -105,6 +105,106 @@ mock_interval_entity = {
     "latent": False,
 }
 
+mock_interval_entity_from = {
+    "body": "from 2 am",
+    "start": 0,
+    "value": {
+        "values": [
+            {
+                "from": {
+                    "value": "2021-01-22T02:00:00.000+05:30",
+                    "grain": "hour",
+                },
+                "type": "interval",
+            },
+            {
+                "from": {
+                    "value": "2021-01-23T02:00:00.000+05:30",
+                    "grain": "hour",
+                },
+                "type": "interval",
+            },
+            {
+                "from": {
+                    "value": "2021-01-24T02:00:00.000+05:30",
+                    "grain": "hour",
+                },
+                "type": "interval",
+            },
+        ],
+        "from": {"value": "2021-01-22T02:00:00.000+05:30", "grain": "hour"},
+        "type": "interval",
+    },
+    "end": 9,
+    "dim": "time",
+    "latent": False,
+    "range": {"start": 0, "end": 9},
+    "type": "time",
+    "values": [
+        {
+            "from": {"value": "2021-01-22T02:00:00.000+05:30", "grain": "hour"},
+            "type": "interval",
+        }
+    ],
+}
+
+mock_interval_entity_to = {
+    "body": "to 4 am",
+    "start": 0,
+    "value": {
+        "values": [
+            {
+                "to": {
+                    "value": "2021-01-22T05:00:00.000+05:30",
+                    "grain": "hour",
+                },
+                "type": "interval",
+            },
+            {
+                "to": {
+                    "value": "2021-01-23T05:00:00.000+05:30",
+                    "grain": "hour",
+                },
+                "type": "interval",
+            },
+            {
+                "to": {
+                    "value": "2021-01-24T05:00:00.000+05:30",
+                    "grain": "hour",
+                },
+                "type": "interval",
+            },
+        ],
+        "to": {"value": "2021-01-22T05:00:00.000+05:30", "grain": "hour"},
+        "type": "interval",
+    },
+    "end": 7,
+    "dim": "time",
+    "latent": False,
+}
+
+mock_bad_interval_entity = {
+    "body": "between 2 am to 4 am",
+    "start": 0,
+    "value": {
+        "values": [
+            {
+                "type": "interval",
+            },
+            {
+                "type": "interval",
+            },
+            {
+                "type": "interval",
+            },
+        ],
+        "type": "interval",
+    },
+    "end": 17,
+    "dim": "time",
+    "latent": False,
+}
+
 mock_people_entity = {
     "body": "3 people",
     "start": 67,

--- a/tests/parser/text/entity/test_duckling_parser.py
+++ b/tests/parser/text/entity/test_duckling_parser.py
@@ -239,6 +239,57 @@ def test_entity_json_to_object_time_interval_entity():
     assert isinstance(entities[0], TimeIntervalEntity)
 
 
+# == Test transformation of entity-json with only `from` key in dictionary to TimeIntervalEntity ==
+def test_entity_json_to_object_time_interval_entity_with_only_from_key():
+    """
+    Reshape converts json response from Duckling APIs
+    to dialogy's BaseEntity.
+
+    We are checking for TimeIntervalEntity here.
+    """
+    parser = DucklingParser(
+        locale="en_IN", dimensions=["time"], timezone="Asia/Kolkata"
+    )
+    entities_json = [config.mock_interval_entity_from]
+
+    entities = parser._reshape(entities_json)
+    assert isinstance(entities[0], TimeIntervalEntity)
+
+
+# == Test transformation of entity-json with only `to` key in dictionary to TimeIntervalEntity ==
+def test_entity_json_to_object_time_interval_entity_with_only_to_key():
+    """
+    Reshape converts json response from Duckling APIs
+    to dialogy's BaseEntity.
+
+    We are checking for TimeIntervalEntity here.
+    """
+    parser = DucklingParser(
+        locale="en_IN", dimensions=["time"], timezone="Asia/Kolkata"
+    )
+    entities_json = [config.mock_interval_entity_to]
+
+    entities = parser._reshape(entities_json)
+    assert isinstance(entities[0], TimeIntervalEntity)
+
+
+# == Test transformation of entity-json with neither `from` nor `to` in dictionary to TimeIntervalEntity ==
+def test_bad_interval_entity():
+    """
+    Reshape converts json response from Duckling APIs
+    to dialogy's BaseEntity.
+
+    We are checking for TimeIntervalEntity here.
+    """
+    parser = DucklingParser(
+        locale="en_IN", dimensions=["time"], timezone="Asia/Kolkata"
+    )
+    entities_json = config.mock_bad_interval_entity
+
+    with pytest.raises(TypeError):
+        parser._mutate_entity(entities_json)
+
+
 # == Test transformation of entity-json to NumericalEntity ==
 def test_entity_json_to_object_numerical_entity() -> None:
     """

--- a/tests/types/entity/test_entities.py
+++ b/tests/types/entity/test_entities.py
@@ -330,3 +330,36 @@ def test_both_entity_type_attributes_match() -> None:
         values=[value],
     )
     assert entity.type == entity.entity_type
+
+
+def test_interval_entity_only_from() -> None:
+    body = "from 2 am"
+    value = {
+        "from": {"value": "2021-01-22T02:00:00.000+05:30", "grain": "hour"},
+    }
+    entity = TimeIntervalEntity(
+        range={"from": 0, "to": len(body)},
+        body=body,
+        type="time",
+        grain="hour",
+        values=[value],
+    )
+    entity.set_value(value=value)
+    print(entity)
+    assert entity.value == value
+
+
+def test_interval_entity_only_to() -> None:
+    body = "to 4 am"
+    value = {
+        "to": {"value": "2021-01-22T04:00:00.000+05:30", "grain": "hour"},
+    }
+    entity = TimeIntervalEntity(
+        range={"from": 0, "to": len(body)},
+        body=body,
+        type="time",
+        grain="hour",
+        values=[value],
+    )
+    entity.set_value(value=value)
+    assert entity.value == value


### PR DESCRIPTION
Added flexibility for time interval entities where we only get one of `from` or `to` values from Duckling parser.