### PR TITLE
feat: added support for --vcs to use git based local templates with copier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - [x] feat: spacy, pattern entity parsing from list support.
 - [x] refactor: Plugin class to prevent repeated code in subclasses.
 - [x] refactor: @debug -> @dbg to prevent name collisions.
+- [x] feat: support for building from local git templates optionally, `--vcs` takes `"TAG"` or `"HEAD"`. if the user provides `--vcs` as
+`"TAG"`, then `dialogy` takes the template's latest released tag commit. if the user provides `--vcs` as `"HEAD"`, then `dialogy` takes the template's present git branch's recent commit.
 
 # 0.5.5
 

--- a/dialogy/cli/__init__.py
+++ b/dialogy/cli/__init__.py
@@ -101,5 +101,5 @@ def main() -> None:
             f'--vcs expects either "HEAD" or "TAG" but was passed {vcs_ref}, \
             see more in --help')
 
-    template_name, namespace = canonicalize_project_name(template_name, namespace, vcs_ref) # ignore: too-many-function-args
+    template_name, namespace = canonicalize_project_name(template_name, namespace, vcs_ref) # pylint: disable = too-many-function-args
     new_project(project_name, template_name, namespace)

--- a/dialogy/cli/__init__.py
+++ b/dialogy/cli/__init__.py
@@ -101,5 +101,5 @@ def main() -> None:
             f'--vcs expects either "HEAD" or "TAG" but was passed {vcs_ref}, \
             see more in --help')
 
-    template_name, namespace = canonicalize_project_name(template_name, namespace, vcs_ref)
+    template_name, namespace = canonicalize_project_name(template_name, namespace, vcs_ref) # ignore: too-many-function-args
     new_project(project_name, template_name, namespace)


### PR DESCRIPTION
for building projects from local `git` based templates, [copier](https://github.com/copier-org/copier) has a limitation at the moment. 

let me explain.

we use [copier](https://github.com/copier-org/copier) for generating projects using jinja templates. if these templates use `git`, `copier` assumes the `template` you are passing via `dialogy` is up-to date. therefore, 

* `copier` builds project from the latest `git` release tag for that template.
* Or uses the latest commit if explicitly passed saying so, that use the `HEAD` commit from the active branch.

there is no other way, you have to use `git`.

so people who are trying to build from local git templates to generate project (using `dialogy` or `copier`). to get instant feeback

1. create new branch for the changes in the template/jinja files (not the `main`/`master` branch)
2. add/stage the changes
3. commit it with a sensible message
4. and use this template with either
```bash
copier <template_src__local_path> <dst_path> --vcs-ref="HEAD"
```
(the above works for now actually)
```bash
dialogy create <template_src_local_path> --vcs="HEAD"
```
this :point_up: will work from next dialogy release i suppose.

 therefore the extra optional tag, `--vcs` flag. 